### PR TITLE
add missing requirements to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,8 @@ requirements = [
     'redis==2.10.6',
     'python-dotenv==0.9.1',
     'ujson==1.35',
-    'autopep8==1.4.3'
+    'autopep8==1.4.3',
+    'coloredlogs==10.0'
 ]
 
 ext_errors = (CCompilerError, DistutilsExecError, DistutilsPlatformError)

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,9 @@ requirements = [
     'python-dotenv==0.9.1',
     'ujson==1.35',
     'autopep8==1.4.3',
-    'coloredlogs==10.0'
+    'coloredlogs==10.0',
+    'transitions==0.6.9',
+    'astor==0.7.1'
 ]
 
 ext_errors = (CCompilerError, DistutilsExecError, DistutilsPlatformError)


### PR DESCRIPTION
without it running the examples produced missing module errors.